### PR TITLE
config file and tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,17 @@ node_js:
   - '0.12'
   - '4.2'
   - 'stable'
+before_install:
+  - sudo apt-get update -qq
+  - sudo apt-get install -qq php5
 install:
-  - cd twig-pl-core && npm install
+  - cd twig-pl-core
+  - alias composer="php composer.phar"
+  - curl -sS https://getcomposer.org/installer | php
+  - npm install # we have a `postinstall` hook that runs `composer install`
+before_script:
+  - php --version
+  - composer --version
 script:
-  - cd twig-pl-core && npm test
+  - pwd
+  - npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: node_js
+node_js:
+  - '0.12'
+  - '4.2'
+  - 'stable'
+install:
+  - cd twig-pl-core && npm install
+script:
+  - cd twig-pl-core && npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ before_install:
   - curl -sS https://getcomposer.org/installer | php
   - mv composer.phar composer
   - export PATH=$PATH:$PWD/
-before_install:
   - php --version
   - composer --version
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: php
 php:
   - 5.5
+before_install:
+  - rm -rf ~/.nvm && git clone https://github.com/creationix/nvm.git ~/.nvm && source ~/.nvm/nvm.sh && nvm install 4.2
 install:
   - cd twig-pl-core && npm install # we have a `postinstall` hook that runs `composer install`
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,13 +6,14 @@ node_js:
 before_install:
   - sudo apt-get update -qq
   - sudo apt-get install -qq php5
-  - brew update
-  - brew install composer
+  - curl -sS https://getcomposer.org/installer | php
+  - mv composer.phar composer
+  - export PATH=$PATH:$PWD/
+before_install:
   - php --version
   - composer --version
 install:
-  - cd twig-pl-core
-  - npm install # we have a `postinstall` hook that runs `composer install`
+  - cd twig-pl-core && npm install # we have a `postinstall` hook that runs `composer install`
 script:
   - pwd
   - npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,14 +6,13 @@ node_js:
 before_install:
   - sudo apt-get update -qq
   - sudo apt-get install -qq php5
-install:
-  - cd twig-pl-core
-  - alias composer="php composer.phar"
-  - curl -sS https://getcomposer.org/installer | php
-  - npm install # we have a `postinstall` hook that runs `composer install`
-before_script:
+  - brew update
+  - brew install composer
   - php --version
   - composer --version
+install:
+  - cd twig-pl-core
+  - npm install # we have a `postinstall` hook that runs `composer install`
 script:
   - pwd
   - npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,6 @@ node_js:
   - '4.2'
   - 'stable'
 before_install:
-  - sudo apt-get update -qq
-  - sudo apt-get install -qq php5
   - curl -sS https://getcomposer.org/installer | php
   - mv composer.phar composer
   - export PATH=$PATH:$PWD/
@@ -17,3 +15,7 @@ install:
 script:
   - pwd
   - npm test
+addons:
+  apt:
+    packages:
+      - php

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,7 @@
-language: node_js
-node_js:
-  - '0.12'
-  - '4.2'
-  - 'stable'
-before_install:
-  - curl -sS https://getcomposer.org/installer | php
-  - mv composer.phar composer
-  - export PATH=$PATH:$PWD/
-  - php --version
-  - composer --version
+language: php
+php:
+  - 5.5
 install:
   - cd twig-pl-core && npm install # we have a `postinstall` hook that runs `composer install`
 script:
-  - pwd
   - npm test
-addons:
-  apt:
-    packages:
-      - php

--- a/twig-pl-core/.gitignore
+++ b/twig-pl-core/.gitignore
@@ -1,5 +1,5 @@
 node_modules
 dist
-
 /vendor/
 bin/cache
+tests/*/dist/

--- a/twig-pl-core/.travis.yml
+++ b/twig-pl-core/.travis.yml
@@ -1,5 +1,0 @@
-language: node_js
-node_js:
-  - '0.12'
-  - '4.2'
-  - 'stable'

--- a/twig-pl-core/.travis.yml
+++ b/twig-pl-core/.travis.yml
@@ -1,0 +1,5 @@
+language: node_js
+node_js:
+  - '0.12'
+  - '4.2'
+  - 'stable'

--- a/twig-pl-core/bin/compile-tpl.php
+++ b/twig-pl-core/bin/compile-tpl.php
@@ -6,27 +6,43 @@ use Symfony\Component\Finder\Finder;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Filesystem\Exception\IOExceptionInterface;
 
-$srcPath = __DIR__.'/../src/';
-
 $fs = new Filesystem();
 $yamlParser = new Parser();
-$loader = new Twig_Loader_Filesystem($srcPath);
-$loader->addPath($srcPath . 'atoms', 'atoms');
-$loader->addPath($srcPath . 'molecules', 'molecules');
-$loader->addPath($srcPath . 'organisms', 'organisms');
+
+// Getting config file
+// The first argument to this script is a path to a configuration yaml file; relative to CWD.
+$configFilePath = $argv[1];
+$configFileDir = dirname($configFilePath);
+$config = $yamlParser->parse(file_get_contents($configFilePath));
+// changing working directory to where config file is, so we can use it's relative paths
+chdir($configFileDir);
+
+$loader = new Twig_Loader_Filesystem($config['src']);
+// @todo Dynamically look at all folders in `$config['src']` and add them via `$loader-addPath()` so Twig knows of them.
+//$loader->addPath($config['src'] . 'atoms', 'atoms');
+//$loader->addPath($config['src'] . 'molecules', 'molecules');
+//$loader->addPath($config['src'] . 'organisms', 'organisms');
 $finder = new Finder();
+
 $twig = new Twig_Environment($loader, array(
-  'cache' => './cache',
+  'cache' => __DIR__ . '/cache', // `__DIR__` is still the directory where this file resides
 ));
 
-$globalData = $yamlParser->parse(file_get_contents(__DIR__.'/../src/data/data.yml'));
+// $config['globalData'] is an array of file paths to data files, we'll merge them all together
+$globalData = array();
+if (isset($config['globalData'])) {
+    foreach ($config['globalData'] as $file) {
+        $chunk = $yamlParser->parse(file_get_contents($file));
+        $globalData = array_merge($globalData, $chunk);
+    }
+}
 
-$finder->files()->in(__DIR__.'/../src')->name('*.twig');
+$finder->files()->in($config['src'])->name('*.twig');
 
 foreach ($finder as $file) {
   $path = $file->getRelativePathname();
   
-  $localDataPath = $srcPath.str_replace(".twig", ".yml", $path);
+  $localDataPath = $config['src'] . str_replace(".twig", ".yml", $path);
   if ($fs->exists($localDataPath)) {
     $localData = $yamlParser->parse(file_get_contents($localDataPath));
     $data = array_merge($globalData,$localData);
@@ -37,7 +53,7 @@ foreach ($finder as $file) {
 
   $template = $twig->loadTemplate($path);
   $html = $template->render($data);
-  $fileDest = '../dist/' . str_replace(".twig", ".html", $path);
+  $fileDest = $config['dist'] . str_replace(".twig", ".html", $path);
 
   try {
     $fs->mkdir(dirname($fileDest));
@@ -47,5 +63,3 @@ foreach ($finder as $file) {
   }
 
 }
-
-?>

--- a/twig-pl-core/bin/compile-tpl.php
+++ b/twig-pl-core/bin/compile-tpl.php
@@ -11,6 +11,7 @@ $yamlParser = new Parser();
 
 // Getting config file
 // The first argument to this script is a path to a configuration yaml file; relative to CWD.
+chdir(getcwd());
 $configFilePath = $argv[1];
 $configFileDir = dirname($configFilePath);
 $config = $yamlParser->parse(file_get_contents($configFilePath));

--- a/twig-pl-core/index.js
+++ b/twig-pl-core/index.js
@@ -1,0 +1,13 @@
+'use strict';
+var path = require('path');
+var execSync = require('child_process').execSync;
+
+function sh (cmd) {
+  return execSync(cmd, {encoding: 'utf8'});
+}
+
+module.exports = function(configFilePath) {
+  var pathToCompile = path.resolve(__dirname, 'bin/compile-tpl.php');
+  var command = 'php ' + path.relative(process.cwd(), pathToCompile) + ' ' + configFilePath;
+  sh(command);
+};

--- a/twig-pl-core/package.json
+++ b/twig-pl-core/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "browser-sync": "^2.11.1",
+    "mocha": "^2.4.5",
     "nodemon": "^1.9.1"
   },
   "devDependencies": {

--- a/twig-pl-core/package.json
+++ b/twig-pl-core/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "compile": "rm -rf dist && cd bin && php compile-tpl.php",
     "postinstall": "composer install",
-    "test": "npm run compile",
+    "test": "mocha tests/**/*.test.js",
     "serve": "browser-sync start --server dist/ --directory --port 3023",
     "watch:src": "nodemon --watch src/ --ext twig,yml --exec 'npm run compile && browser-sync reload --port 3023' ",
     "start": "npm run compile && (npm run serve & npm run watch:src)"

--- a/twig-pl-core/package.json
+++ b/twig-pl-core/package.json
@@ -2,7 +2,7 @@
   "name": "twig-pattern-library",
   "version": "1.0.0",
   "description": "",
-  "main": "bin/compile-tpl.php",
+  "main": "index.js",
   "scripts": {
     "compile": "rm -rf dist && cd bin && php compile-tpl.php",
     "postinstall": "composer install",

--- a/twig-pl-core/readme.md
+++ b/twig-pl-core/readme.md
@@ -20,3 +20,9 @@ To clean, build, serve and watch:
 To simply clean and compile:
 
 		npm run compile
+
+# Testing
+
+To run tests:
+
+		npm test

--- a/twig-pl-core/tests/basics/basic-compile-w-global-data/config.yml
+++ b/twig-pl-core/tests/basics/basic-compile-w-global-data/config.yml
@@ -1,0 +1,4 @@
+src: src/
+dist: dist/
+globalData:
+  - data.yml

--- a/twig-pl-core/tests/basics/basic-compile-w-global-data/data.yml
+++ b/twig-pl-core/tests/basics/basic-compile-w-global-data/data.yml
@@ -1,0 +1,1 @@
+text: From global data

--- a/twig-pl-core/tests/basics/basic-compile-w-global-data/expected/button.html
+++ b/twig-pl-core/tests/basics/basic-compile-w-global-data/expected/button.html
@@ -1,0 +1,1 @@
+<a href="/" class="btn">From local data</a>

--- a/twig-pl-core/tests/basics/basic-compile-w-global-data/expected/button.html
+++ b/twig-pl-core/tests/basics/basic-compile-w-global-data/expected/button.html
@@ -1,1 +1,1 @@
-<a href="/" class="btn">From local data</a>
+<a href="/" class="btn">From global data</a>

--- a/twig-pl-core/tests/basics/basic-compile-w-global-data/src/button.twig
+++ b/twig-pl-core/tests/basics/basic-compile-w-global-data/src/button.twig
@@ -1,0 +1,1 @@
+<a href="/" class="btn">{{ text }}</a>

--- a/twig-pl-core/tests/basics/basic-compile-w-local-data/config.yml
+++ b/twig-pl-core/tests/basics/basic-compile-w-local-data/config.yml
@@ -1,0 +1,2 @@
+src: src/
+dist: dist/

--- a/twig-pl-core/tests/basics/basic-compile-w-local-data/expected/button.html
+++ b/twig-pl-core/tests/basics/basic-compile-w-local-data/expected/button.html
@@ -1,0 +1,1 @@
+<a href="/" class="btn">From local data</a>

--- a/twig-pl-core/tests/basics/basic-compile-w-local-data/src/button.twig
+++ b/twig-pl-core/tests/basics/basic-compile-w-local-data/src/button.twig
@@ -1,0 +1,1 @@
+<a href="/" class="btn">{{ text }}</a>

--- a/twig-pl-core/tests/basics/basic-compile-w-local-data/src/button.yml
+++ b/twig-pl-core/tests/basics/basic-compile-w-local-data/src/button.yml
@@ -1,0 +1,1 @@
+text: From local data

--- a/twig-pl-core/tests/basics/basic-compile/config.yml
+++ b/twig-pl-core/tests/basics/basic-compile/config.yml
@@ -1,0 +1,2 @@
+src: src/
+dist: dist/

--- a/twig-pl-core/tests/basics/basic-compile/expected/button.html
+++ b/twig-pl-core/tests/basics/basic-compile/expected/button.html
@@ -1,0 +1,1 @@
+<a href="/" class="btn">Button with hard coded text</a>

--- a/twig-pl-core/tests/basics/basic-compile/src/button.twig
+++ b/twig-pl-core/tests/basics/basic-compile/src/button.twig
@@ -1,0 +1,1 @@
+<a href="/" class="btn">Button with hard coded text</a>

--- a/twig-pl-core/tests/basics/basics.test.js
+++ b/twig-pl-core/tests/basics/basics.test.js
@@ -1,0 +1,31 @@
+var assert = require('assert');
+var fs = require('fs');
+var path = require('path');
+var compile = require('../../index.js');
+
+describe('Basics', function() {
+  describe('basic-compile', function () {
+    it('should compile Twig to HTML', function () {
+      compile(path.join(__dirname, './basic-compile/config.yml'));
+      var expected = fs.readFileSync(path.join(__dirname, './basic-compile/expected/button.html'), 'utf8');
+      var actual = fs.readFileSync(path.join(__dirname, './basic-compile/dist/button.html'), 'utf8');
+      assert.equal(expected, actual);
+    });
+  });
+  describe('basic-compile-w-global-data', function () {
+    it('should use global data', function () {
+      compile(path.join(__dirname, './basic-compile-w-global-data/config.yml'));
+      var expected = fs.readFileSync(path.join(__dirname, './basic-compile-w-global-data/expected/button.html'), 'utf8');
+      var actual = fs.readFileSync(path.join(__dirname, './basic-compile-w-global-data/dist/button.html'), 'utf8');
+      assert.equal(expected, actual);
+    });
+  });
+  describe('basic-compile-w-local-data', function () {
+    it('should use local data', function () {
+      compile(path.join(__dirname, './basic-compile-w-local-data/config.yml'));
+      var expected = fs.readFileSync(path.join(__dirname, './basic-compile-w-local-data/expected/button.html'), 'utf8');
+      var actual = fs.readFileSync(path.join(__dirname, './basic-compile-w-local-data/dist/button.html'), 'utf8');
+      assert.equal(expected, actual);
+    });
+  });
+});


### PR DESCRIPTION
This sets it up so the path to a config file is the first argument to our build script:

    php bin/compile-tpl.php path/to/config.yml

That config file can contain this data so far:

```yml
src: path/to/src
dist: path/to/dist
globalData: # this all gets merged together into one `$globalData`
  - path/to/global.yml
  - another/path/to/more/global.yml
```

I've made a node wrapper around the php file in `index.js` that'll let us require it, pass in a path to a config file, and it'll compile the site. This is how outside utilities can compile.

Additionally, I've got the beginnings of files in the `tests/` folder that can test run compiles for us; very excited about this! I'd like to see more of these get created and hashed out. 

This all fixes #1 too.